### PR TITLE
Refactors code to extract CRDs from UI code

### DIFF
--- a/package.json
+++ b/package.json
@@ -74,8 +74,8 @@
     "displayName": "OCP Secrets Management",
     "description": "OpenShift Console plugin for managing secrets and sensitive data.",
     "exposedModules": {
-      "SecretsManagement": "./components/SecretsManagement",
-      "ResourceInspect": "./components/ResourceInspect"
+      "SecretsManagement": "./SecretsManagement",
+      "ResourceInspect": "./ResourceInspect"
     },
     "dependencies": {
       "@console/pluginAPI": "*"

--- a/src/ResourceInspect.tsx
+++ b/src/ResourceInspect.tsx
@@ -20,87 +20,12 @@ import {
 } from '@patternfly/react-core';
 import { ArrowLeftIcon, KeyIcon, CheckCircleIcon, TimesCircleIcon } from '@patternfly/react-icons';
 import { useK8sWatchResource } from '@openshift-console/dynamic-plugin-sdk';
-
-// Resource models
-const CertificateModel = {
-  group: 'cert-manager.io',
-  version: 'v1',
-  kind: 'Certificate',
-};
-
-const IssuerModel = {
-  group: 'cert-manager.io',
-  version: 'v1',
-  kind: 'Issuer',
-};
-
-const ClusterIssuerModel = {
-  group: 'cert-manager.io',
-  version: 'v1',
-  kind: 'ClusterIssuer',
-};
-
-const ExternalSecretModel = {
-  group: 'external-secrets.io',
-  version: 'v1',
-  kind: 'ExternalSecret',
-};
-
-const ClusterExternalSecretModel = {
-  group: 'external-secrets.io',
-  version: 'v1',
-  kind: 'ClusterExternalSecret',
-};
-
-const SecretStoreModel = {
-  group: 'external-secrets.io',
-  version: 'v1',
-  kind: 'SecretStore',
-};
-
-const ClusterSecretStoreModel = {
-  group: 'external-secrets.io',
-  version: 'v1',
-  kind: 'ClusterSecretStore',
-};
-
-const SecretProviderClassModel = {
-  group: 'secrets-store.csi.x-k8s.io',
-  version: 'v1',
-  kind: 'SecretProviderClass',
-};
-
-const SecretProviderClassPodStatusModel = {
-  group: 'secrets-store.csi.x-k8s.io',
-  version: 'v1',
-  kind: 'SecretProviderClassPodStatus',
-};
-
-const PushSecretModel = {
-  group: 'external-secrets.io',
-  version: 'v1alpha1',
-  kind: 'PushSecret',
-};
-
-const ClusterPushSecretModel = {
-  group: 'external-secrets.io',
-  version: 'v1alpha1',
-  kind: 'ClusterPushSecret',
-};
-
-interface SecretProviderClassPodStatus {
-  metadata: {
-    name: string;
-    namespace: string;
-    creationTimestamp: string;
-  };
-  status: {
-    mounted: boolean;
-    secretProviderClassName: string;
-    podName?: string;
-    targetPath?: string;
-  };
-}
+import { CertificateModel } from './components/crds/Certificate';
+import { IssuerModel, ClusterIssuerModel } from './components/crds/Issuer';
+import { ExternalSecretModel, ClusterExternalSecretModel } from './components/crds/ExternalSecret';
+import { SecretStoreModel, ClusterSecretStoreModel } from './components/crds/SecretStore';
+import { PushSecretModel, ClusterPushSecretModel } from './components/crds/PushSecret';
+import { SecretProviderClassModel, SecretProviderClassPodStatusModel, SecretProviderClassPodStatus } from './components/crds/SecretProviderClass';
 
 export const ResourceInspect: React.FC = () => {
   const { t } = useTranslation('plugin__ocp-secrets-management');

--- a/src/ResourceInspect.tsx
+++ b/src/ResourceInspect.tsx
@@ -591,3 +591,4 @@ export const ResourceInspect: React.FC = () => {
     </>
   );
 };
+

--- a/src/SecretsManagement.tsx
+++ b/src/SecretsManagement.tsx
@@ -13,12 +13,12 @@ import {
   FlexItem,
 } from '@patternfly/react-core';
 import { KeyIcon } from '@patternfly/react-icons';
-import { CertificatesTable } from './CertificatesTable';
-import { IssuersTable } from './IssuersTable';
-import { ExternalSecretsTable } from './ExternalSecretsTable';
-import { SecretStoresTable } from './SecretStoresTable';
-import { PushSecretsTable } from './PushSecretsTable';
-import { SecretProviderClassTable } from './SecretProviderClassTable';
+import { CertificatesTable } from './components/CertificatesTable';
+import { IssuersTable } from './components/IssuersTable';
+import { ExternalSecretsTable } from './components/ExternalSecretsTable';
+import { SecretStoresTable } from './components/SecretStoresTable';
+import { PushSecretsTable } from './components/PushSecretsTable';
+import { SecretProviderClassTable } from './components/SecretProviderClassTable';
 import { useK8sWatchResource } from '@openshift-console/dynamic-plugin-sdk';
 
 type OperatorType = 'cert-manager' | 'external-secrets' | 'secrets-store-csi' | 'all';
@@ -394,3 +394,4 @@ export default function SecretsManagement() {
     </>
   );
 }
+

--- a/src/components/CertificatesTable.tsx
+++ b/src/components/CertificatesTable.tsx
@@ -17,40 +17,7 @@ import {
 import { CheckCircleIcon, ExclamationCircleIcon, TimesCircleIcon, EllipsisVIcon } from '@patternfly/react-icons';
 import { ResourceTable } from './ResourceTable';
 import { useK8sWatchResource, consoleFetch } from '@openshift-console/dynamic-plugin-sdk';
-
-// Certificate custom resource definition from cert-manager
-const CertificateModel = {
-  group: 'cert-manager.io',
-  version: 'v1',
-  kind: 'Certificate',
-};
-
-interface Certificate {
-  metadata: {
-    name: string;
-    namespace: string;
-    creationTimestamp: string;
-  };
-  spec: {
-    secretName: string;
-    issuerRef: {
-      name: string;
-      kind: string;
-    };
-    dnsNames?: string[];
-    commonName?: string;
-  };
-  status?: {
-    conditions?: Array<{
-      type: string;
-      status: string;
-      reason?: string;
-      message?: string;
-    }>;
-    renewalTime?: string;
-    notAfter?: string;
-  };
-}
+import { CertificateModel, Certificate } from './crds/Certificate';
 
 const getConditionStatus = (certificate: Certificate) => {
   const readyCondition = certificate.status?.conditions?.find(

--- a/src/components/ExternalSecretsTable.tsx
+++ b/src/components/ExternalSecretsTable.tsx
@@ -17,104 +17,14 @@ import {
 import { CheckCircleIcon, ExclamationCircleIcon, TimesCircleIcon, SyncAltIcon, EllipsisVIcon } from '@patternfly/react-icons';
 import { ResourceTable } from './ResourceTable';
 import { useK8sWatchResource, consoleFetch } from '@openshift-console/dynamic-plugin-sdk';
-
-// ExternalSecret custom resource definition from external-secrets-operator
-const ExternalSecretModel = {
-  group: 'external-secrets.io',
-  version: 'v1',
-  kind: 'ExternalSecret',
-};
-
-// ClusterExternalSecret custom resource definition from external-secrets-operator
-const ClusterExternalSecretModel = {
-  group: 'external-secrets.io',
-  version: 'v1',
-  kind: 'ClusterExternalSecret',
-};
-
-interface ExternalSecret {
-  metadata: {
-    name: string;
-    namespace: string;
-    creationTimestamp: string;
-  };
-  spec: {
-    secretStoreRef?: {
-      name: string;
-      kind: string;
-    };
-    target?: {
-      name?: string;
-      creationPolicy?: string;
-    };
-    refreshInterval?: string;
-    data?: Array<{
-      secretKey: string;
-      remoteRef: {
-        key: string;
-        property?: string;
-      };
-    }>;
-  };
-  status?: {
-    conditions?: Array<{
-      type: string;
-      status: string;
-      reason?: string;
-      message?: string;
-    }>;
-    refreshTime?: string;
-    syncedResourceVersion?: string;
-  };
-}
-
-interface ClusterExternalSecret {
-  metadata: {
-    name: string;
-    namespace?: string; // ClusterExternalSecret is cluster-scoped
-    creationTimestamp: string;
-  };
-  spec: {
-    externalSecretSpec: {
-      secretStoreRef?: {
-        name: string;
-        kind: string;
-      };
-      target?: {
-        name?: string;
-        creationPolicy?: string;
-      };
-      refreshInterval?: string;
-      data?: Array<{
-        secretKey: string;
-        remoteRef: {
-          key: string;
-          property?: string;
-        };
-      }>;
-    };
-    namespaceSelector?: {
-      matchLabels?: Record<string, string>;
-    };
-    refreshTime?: string;
-  };
-  status?: {
-    conditions?: Array<{
-      type: string;
-      status: string;
-      reason?: string;
-      message?: string;
-    }>;
-    provisionedNamespaces?: number;
-    failedNamespaces?: number;
-  };
-}
-
-type ExternalSecretResource = ExternalSecret | ClusterExternalSecret;
-
-const isClusterExternalSecret = (resource: ExternalSecretResource): resource is ClusterExternalSecret => {
-  return 'externalSecretSpec' in resource.spec;
-};
+import { 
+  ExternalSecretModel, 
+  ClusterExternalSecretModel, 
+  ExternalSecret, 
+  ClusterExternalSecret,
+  ExternalSecretResource,
+  isClusterExternalSecret
+} from './crds/ExternalSecret';
 
 const getConditionStatus = (externalSecret: ExternalSecretResource) => {
   const readyCondition = externalSecret.status?.conditions?.find(

--- a/src/components/IssuersTable.tsx
+++ b/src/components/IssuersTable.tsx
@@ -17,48 +17,7 @@ import {
 import { CheckCircleIcon, ExclamationCircleIcon, TimesCircleIcon, EllipsisVIcon } from '@patternfly/react-icons';
 import { ResourceTable } from './ResourceTable';
 import { useK8sWatchResource, consoleFetch } from '@openshift-console/dynamic-plugin-sdk';
-
-// Issuer and ClusterIssuer models from cert-manager
-const IssuerModel = {
-  group: 'cert-manager.io',
-  version: 'v1',
-  kind: 'Issuer',
-};
-
-const ClusterIssuerModel = {
-  group: 'cert-manager.io',
-  version: 'v1',
-  kind: 'ClusterIssuer',
-};
-
-interface Issuer {
-  metadata: {
-    name: string;
-    namespace?: string;
-    creationTimestamp: string;
-  };
-  spec: {
-    acme?: {
-      server: string;
-      email?: string;
-    };
-    ca?: {
-      secretName: string;
-    };
-    selfSigned?: {};
-    vault?: {
-      server: string;
-    };
-  };
-  status?: {
-    conditions?: Array<{
-      type: string;
-      status: string;
-      reason?: string;
-      message?: string;
-    }>;
-  };
-}
+import { IssuerModel, ClusterIssuerModel, Issuer } from './crds/Issuer';
 
 const getIssuerType = (issuer: Issuer): string => {
   if (issuer.spec.acme) return 'ACME';

--- a/src/components/PushSecretsTable.tsx
+++ b/src/components/PushSecretsTable.tsx
@@ -17,113 +17,14 @@ import {
 import { CheckCircleIcon, ExclamationCircleIcon, TimesCircleIcon, EllipsisVIcon, SyncAltIcon } from '@patternfly/react-icons';
 import { ResourceTable } from './ResourceTable';
 import { useK8sWatchResource, consoleFetch } from '@openshift-console/dynamic-plugin-sdk';
-
-// PushSecret model from external-secrets-operator
-const PushSecretModel = {
-  group: 'external-secrets.io',
-  version: 'v1alpha1',
-  kind: 'PushSecret',
-};
-
-// ClusterPushSecret model from external-secrets-operator
-const ClusterPushSecretModel = {
-  group: 'external-secrets.io',
-  version: 'v1alpha1',
-  kind: 'ClusterPushSecret',
-};
-
-interface PushSecret {
-  metadata: {
-    name: string;
-    namespace: string;
-    creationTimestamp: string;
-    labels?: Record<string, string>;
-    annotations?: Record<string, string>;
-  };
-  spec: {
-    refreshInterval?: string;
-    secretStoreRefs: Array<{
-      name: string;
-      kind: string;
-    }>;
-    selector: {
-      secret: {
-        name: string;
-      };
-    };
-    data?: Array<{
-      match: {
-        secretKey: string;
-        remoteRef: {
-          remoteKey: string;
-          property?: string;
-        };
-      };
-    }>;
-  };
-  status?: {
-    conditions?: Array<{
-      type: string;
-      status: string;
-      reason?: string;
-      message?: string;
-      lastTransitionTime?: string;
-    }>;
-    refreshTime?: string;
-    syncedResourceVersion?: string;
-  };
-}
-
-interface ClusterPushSecret {
-  metadata: {
-    name: string;
-    namespace?: string; // ClusterPushSecret is cluster-scoped
-    creationTimestamp: string;
-    labels?: Record<string, string>;
-    annotations?: Record<string, string>;
-  };
-  spec: {
-    refreshInterval?: string;
-    secretStoreRefs: Array<{
-      name: string;
-      kind: string;
-    }>;
-    selector: {
-      secret: {
-        name: string;
-      };
-    };
-    namespaceSelector?: {
-      matchLabels?: Record<string, string>;
-    };
-    data?: Array<{
-      match: {
-        secretKey: string;
-        remoteRef: {
-          remoteKey: string;
-          property?: string;
-        };
-      };
-    }>;
-  };
-  status?: {
-    conditions?: Array<{
-      type: string;
-      status: string;
-      reason?: string;
-      message?: string;
-      lastTransitionTime?: string;
-    }>;
-    refreshTime?: string;
-    syncedResourceVersion?: string;
-  };
-}
-
-type PushSecretResource = PushSecret | ClusterPushSecret;
-
-const isClusterPushSecret = (resource: PushSecretResource): resource is ClusterPushSecret => {
-  return !resource.metadata.namespace;
-}
+import { 
+  PushSecretModel, 
+  ClusterPushSecretModel, 
+  PushSecret, 
+  ClusterPushSecret,
+  PushSecretResource,
+  isClusterPushSecret
+} from './crds/PushSecret';
 
 const getPushSecretStatus = (pushSecret: PushSecretResource) => {
   if (!pushSecret.status?.conditions) {

--- a/src/components/SecretProviderClassTable.tsx
+++ b/src/components/SecretProviderClassTable.tsx
@@ -17,66 +17,12 @@ import {
 import { CheckCircleIcon, ExclamationCircleIcon, TimesCircleIcon, EllipsisVIcon } from '@patternfly/react-icons';
 import { ResourceTable } from './ResourceTable';
 import { useK8sWatchResource, consoleFetch } from '@openshift-console/dynamic-plugin-sdk';
-
-// SecretProviderClass custom resource definition from secrets-store-csi-driver
-const SecretProviderClassModel = {
-  group: 'secrets-store.csi.x-k8s.io',
-  version: 'v1',
-  kind: 'SecretProviderClass',
-};
-
-const SecretProviderClassPodStatusModel = {
-  group: 'secrets-store.csi.x-k8s.io',
-  version: 'v1',
-  kind: 'SecretProviderClassPodStatus',
-};
-
-interface SecretProviderClass {
-  metadata: {
-    name: string;
-    namespace: string;
-    creationTimestamp: string;
-    labels?: Record<string, string>;
-    annotations?: Record<string, string>;
-  };
-  spec: {
-    provider: string;
-    parameters?: Record<string, string>;
-    secretObjects?: Array<{
-      secretName: string;
-      type: string;
-      data: Array<{
-        objectName: string;
-        key: string;
-      }>;
-    }>;
-  };
-  status?: {
-    podStatus?: {
-      [podName: string]: {
-        mounted: boolean;
-        error?: string;
-      };
-    };
-    byPod?: Array<{
-      id: string;
-      namespace: string;
-    }>;
-  };
-}
-
-interface SecretProviderClassPodStatus {
-  metadata: {
-    name: string;
-    namespace: string;
-  };
-  status: {
-    mounted: boolean;
-    secretProviderClassName: string;
-    podName?: string;
-    targetPath?: string;
-  };
-}
+import { 
+  SecretProviderClassModel, 
+  SecretProviderClassPodStatusModel, 
+  SecretProviderClass, 
+  SecretProviderClassPodStatus 
+} from './crds/SecretProviderClass';
 
 const getProviderIcon = (provider: string) => {
   switch (provider.toLowerCase()) {

--- a/src/components/SecretStoresTable.tsx
+++ b/src/components/SecretStoresTable.tsx
@@ -17,49 +17,7 @@ import {
 import { CheckCircleIcon, ExclamationCircleIcon, TimesCircleIcon, EllipsisVIcon } from '@patternfly/react-icons';
 import { ResourceTable } from './ResourceTable';
 import { useK8sWatchResource, consoleFetch } from '@openshift-console/dynamic-plugin-sdk';
-
-// SecretStore and ClusterSecretStore models from external-secrets-operator
-const SecretStoreModel = {
-  group: 'external-secrets.io',
-  version: 'v1',
-  kind: 'SecretStore',
-};
-
-const ClusterSecretStoreModel = {
-  group: 'external-secrets.io',
-  version: 'v1',
-  kind: 'ClusterSecretStore',
-};
-
-interface SecretStore {
-  metadata: {
-    name: string;
-    namespace?: string;
-    creationTimestamp: string;
-  };
-  scope?: 'Namespace' | 'Cluster';
-  spec: {
-    provider: {
-      aws?: { service: string; region?: string };
-      azurekv?: { vaultUrl: string };
-      gcpsm?: { projectId: string };
-      vault?: { server: string };
-      kubernetes?: { server?: string };
-      doppler?: { apiUrl?: string };
-      onepassword?: { connectHost: string };
-      gitlab?: { url?: string };
-      fake?: { data: any[] };
-    };
-  };
-  status?: {
-    conditions?: Array<{
-      type: string;
-      status: string;
-      reason?: string;
-      message?: string;
-    }>;
-  };
-}
+import { SecretStoreModel, ClusterSecretStoreModel, SecretStore } from './crds/SecretStore';
 
 const getProviderType = (secretStore: SecretStore): string => {
   const provider = secretStore.spec.provider;

--- a/src/components/crds/Certificate.ts
+++ b/src/components/crds/Certificate.ts
@@ -1,0 +1,34 @@
+// Certificate custom resource definition from cert-manager
+export const CertificateModel = {
+  group: 'cert-manager.io',
+  version: 'v1',
+  kind: 'Certificate',
+};
+
+export interface Certificate {
+  metadata: {
+    name: string;
+    namespace: string;
+    creationTimestamp: string;
+  };
+  spec: {
+    secretName: string;
+    issuerRef: {
+      name: string;
+      kind: string;
+    };
+    dnsNames?: string[];
+    commonName?: string;
+  };
+  status?: {
+    conditions?: Array<{
+      type: string;
+      status: string;
+      reason?: string;
+      message?: string;
+    }>;
+    renewalTime?: string;
+    notAfter?: string;
+  };
+}
+

--- a/src/components/crds/ExternalSecret.ts
+++ b/src/components/crds/ExternalSecret.ts
@@ -1,0 +1,98 @@
+// ExternalSecret custom resource definition from external-secrets-operator
+export const ExternalSecretModel = {
+  group: 'external-secrets.io',
+  version: 'v1',
+  kind: 'ExternalSecret',
+};
+
+// ClusterExternalSecret custom resource definition from external-secrets-operator
+export const ClusterExternalSecretModel = {
+  group: 'external-secrets.io',
+  version: 'v1',
+  kind: 'ClusterExternalSecret',
+};
+
+export interface ExternalSecret {
+  metadata: {
+    name: string;
+    namespace: string;
+    creationTimestamp: string;
+  };
+  spec: {
+    secretStoreRef?: {
+      name: string;
+      kind: string;
+    };
+    target?: {
+      name?: string;
+      creationPolicy?: string;
+    };
+    refreshInterval?: string;
+    data?: Array<{
+      secretKey: string;
+      remoteRef: {
+        key: string;
+        property?: string;
+      };
+    }>;
+  };
+  status?: {
+    conditions?: Array<{
+      type: string;
+      status: string;
+      reason?: string;
+      message?: string;
+    }>;
+    refreshTime?: string;
+    syncedResourceVersion?: string;
+  };
+}
+
+export interface ClusterExternalSecret {
+  metadata: {
+    name: string;
+    namespace?: string; // ClusterExternalSecret is cluster-scoped
+    creationTimestamp: string;
+  };
+  spec: {
+    externalSecretSpec: {
+      secretStoreRef?: {
+        name: string;
+        kind: string;
+      };
+      target?: {
+        name?: string;
+        creationPolicy?: string;
+      };
+      refreshInterval?: string;
+      data?: Array<{
+        secretKey: string;
+        remoteRef: {
+          key: string;
+          property?: string;
+        };
+      }>;
+    };
+    namespaceSelector?: {
+      matchLabels?: Record<string, string>;
+    };
+    refreshTime?: string;
+  };
+  status?: {
+    conditions?: Array<{
+      type: string;
+      status: string;
+      reason?: string;
+      message?: string;
+    }>;
+    provisionedNamespaces?: number;
+    failedNamespaces?: number;
+  };
+}
+
+export type ExternalSecretResource = ExternalSecret | ClusterExternalSecret;
+
+export const isClusterExternalSecret = (resource: ExternalSecretResource): resource is ClusterExternalSecret => {
+  return 'externalSecretSpec' in resource.spec;
+};
+

--- a/src/components/crds/Issuer.ts
+++ b/src/components/crds/Issuer.ts
@@ -1,0 +1,42 @@
+// Issuer and ClusterIssuer models from cert-manager
+export const IssuerModel = {
+  group: 'cert-manager.io',
+  version: 'v1',
+  kind: 'Issuer',
+};
+
+export const ClusterIssuerModel = {
+  group: 'cert-manager.io',
+  version: 'v1',
+  kind: 'ClusterIssuer',
+};
+
+export interface Issuer {
+  metadata: {
+    name: string;
+    namespace?: string;
+    creationTimestamp: string;
+  };
+  spec: {
+    acme?: {
+      server: string;
+      email?: string;
+    };
+    ca?: {
+      secretName: string;
+    };
+    selfSigned?: {};
+    vault?: {
+      server: string;
+    };
+  };
+  status?: {
+    conditions?: Array<{
+      type: string;
+      status: string;
+      reason?: string;
+      message?: string;
+    }>;
+  };
+}
+

--- a/src/components/crds/PushSecret.ts
+++ b/src/components/crds/PushSecret.ts
@@ -1,0 +1,107 @@
+// PushSecret model from external-secrets-operator
+export const PushSecretModel = {
+  group: 'external-secrets.io',
+  version: 'v1alpha1',
+  kind: 'PushSecret',
+};
+
+// ClusterPushSecret model from external-secrets-operator
+export const ClusterPushSecretModel = {
+  group: 'external-secrets.io',
+  version: 'v1alpha1',
+  kind: 'ClusterPushSecret',
+};
+
+export interface PushSecret {
+  metadata: {
+    name: string;
+    namespace: string;
+    creationTimestamp: string;
+    labels?: Record<string, string>;
+    annotations?: Record<string, string>;
+  };
+  spec: {
+    refreshInterval?: string;
+    secretStoreRefs: Array<{
+      name: string;
+      kind: string;
+    }>;
+    selector: {
+      secret: {
+        name: string;
+      };
+    };
+    data?: Array<{
+      match: {
+        secretKey: string;
+        remoteRef: {
+          remoteKey: string;
+          property?: string;
+        };
+      };
+    }>;
+  };
+  status?: {
+    conditions?: Array<{
+      type: string;
+      status: string;
+      reason?: string;
+      message?: string;
+      lastTransitionTime?: string;
+    }>;
+    refreshTime?: string;
+    syncedResourceVersion?: string;
+  };
+}
+
+export interface ClusterPushSecret {
+  metadata: {
+    name: string;
+    namespace?: string; // ClusterPushSecret is cluster-scoped
+    creationTimestamp: string;
+    labels?: Record<string, string>;
+    annotations?: Record<string, string>;
+  };
+  spec: {
+    refreshInterval?: string;
+    secretStoreRefs: Array<{
+      name: string;
+      kind: string;
+    }>;
+    selector: {
+      secret: {
+        name: string;
+      };
+    };
+    namespaceSelector?: {
+      matchLabels?: Record<string, string>;
+    };
+    data?: Array<{
+      match: {
+        secretKey: string;
+        remoteRef: {
+          remoteKey: string;
+          property?: string;
+        };
+      };
+    }>;
+  };
+  status?: {
+    conditions?: Array<{
+      type: string;
+      status: string;
+      reason?: string;
+      message?: string;
+      lastTransitionTime?: string;
+    }>;
+    refreshTime?: string;
+    syncedResourceVersion?: string;
+  };
+}
+
+export type PushSecretResource = PushSecret | ClusterPushSecret;
+
+export const isClusterPushSecret = (resource: PushSecretResource): resource is ClusterPushSecret => {
+  return !resource.metadata.namespace;
+};
+

--- a/src/components/crds/SecretProviderClass.ts
+++ b/src/components/crds/SecretProviderClass.ts
@@ -1,0 +1,61 @@
+// SecretProviderClass custom resource definition from secrets-store-csi-driver
+export const SecretProviderClassModel = {
+  group: 'secrets-store.csi.x-k8s.io',
+  version: 'v1',
+  kind: 'SecretProviderClass',
+};
+
+export const SecretProviderClassPodStatusModel = {
+  group: 'secrets-store.csi.x-k8s.io',
+  version: 'v1',
+  kind: 'SecretProviderClassPodStatus',
+};
+
+export interface SecretProviderClass {
+  metadata: {
+    name: string;
+    namespace: string;
+    creationTimestamp: string;
+    labels?: Record<string, string>;
+    annotations?: Record<string, string>;
+  };
+  spec: {
+    provider: string;
+    parameters?: Record<string, string>;
+    secretObjects?: Array<{
+      secretName: string;
+      type: string;
+      data: Array<{
+        objectName: string;
+        key: string;
+      }>;
+    }>;
+  };
+  status?: {
+    podStatus?: {
+      [podName: string]: {
+        mounted: boolean;
+        error?: string;
+      };
+    };
+    byPod?: Array<{
+      id: string;
+      namespace: string;
+    }>;
+  };
+}
+
+export interface SecretProviderClassPodStatus {
+  metadata: {
+    name: string;
+    namespace: string;
+    creationTimestamp?: string;
+  };
+  status: {
+    mounted: boolean;
+    secretProviderClassName: string;
+    podName?: string;
+    targetPath?: string;
+  };
+}
+

--- a/src/components/crds/SecretStore.ts
+++ b/src/components/crds/SecretStore.ts
@@ -1,0 +1,43 @@
+// SecretStore and ClusterSecretStore models from external-secrets-operator
+export const SecretStoreModel = {
+  group: 'external-secrets.io',
+  version: 'v1',
+  kind: 'SecretStore',
+};
+
+export const ClusterSecretStoreModel = {
+  group: 'external-secrets.io',
+  version: 'v1',
+  kind: 'ClusterSecretStore',
+};
+
+export interface SecretStore {
+  metadata: {
+    name: string;
+    namespace?: string;
+    creationTimestamp: string;
+  };
+  scope?: 'Namespace' | 'Cluster';
+  spec: {
+    provider: {
+      aws?: { service: string; region?: string };
+      azurekv?: { vaultUrl: string };
+      gcpsm?: { projectId: string };
+      vault?: { server: string };
+      kubernetes?: { server?: string };
+      doppler?: { apiUrl?: string };
+      onepassword?: { connectHost: string };
+      gitlab?: { url?: string };
+      fake?: { data: any[] };
+    };
+  };
+  status?: {
+    conditions?: Array<{
+      type: string;
+      status: string;
+      reason?: string;
+      message?: string;
+    }>;
+  };
+}
+


### PR DESCRIPTION
* Moves modules that are exposed by the plugin to top level `src` dir
* Moves all CRD definitions to `src/components/crds` which is better separation of code. 
* Refactor all files to ensure proper imports