### PR TITLE
Add Expiry Date column, fix table layout

### DIFF
--- a/src/ResourceInspect.tsx
+++ b/src/ResourceInspect.tsx
@@ -333,9 +333,9 @@ export const ResourceInspect: React.FC = () => {
   const renderSecretProviderClassPodStatuses = () => {
     if (resourceType !== 'secretproviderclasses' || !resource) return null;
 
-    // Filter pod statuses that reference this SecretProviderClass
+    // Filter pod statuses that reference this SecretProviderClass (skip entries without status)
     const relevantPodStatuses = (podStatuses || []).filter(
-      podStatus => podStatus.status.secretProviderClassName === resource.metadata.name
+      podStatus => podStatus.status?.secretProviderClassName === resource.metadata.name
     );
 
     if (relevantPodStatuses.length === 0) {
@@ -365,13 +365,13 @@ export const ResourceInspect: React.FC = () => {
               <tbody>
                 {relevantPodStatuses.map((podStatus) => (
                   <tr key={podStatus.metadata.name}>
-                    <td>{podStatus.status.podName || podStatus.metadata.name}</td>
+                    <td>{podStatus.status?.podName || podStatus.metadata.name}</td>
                     <td>
                       <Label 
-                        color={podStatus.status.mounted ? 'green' : 'red'} 
-                        icon={podStatus.status.mounted ? <CheckCircleIcon /> : <TimesCircleIcon />}
+                        color={podStatus.status?.mounted ? 'green' : 'red'} 
+                        icon={podStatus.status?.mounted ? <CheckCircleIcon /> : <TimesCircleIcon />}
                       >
-                        {podStatus.status.mounted ? t('Yes') : t('No')}
+                        {podStatus.status?.mounted ? t('Yes') : t('No')}
                       </Label>
                     </td>
                     <td>{formatTimestamp(podStatus.metadata.creationTimestamp)}</td>

--- a/src/SecretsManagement.tsx
+++ b/src/SecretsManagement.tsx
@@ -198,7 +198,7 @@ export default function SecretsManagement() {
           <Title headingLevel="h1" size="2xl" className="co-m-pane__heading-title">
             <KeyIcon className="co-m-resource-icon co-m-resource-icon--lg" /> {t('Secrets Management')}
           </Title>
-          <p className="help-block">
+          <p className="help-block" style={{ textAlign: 'left' }}>
             {t('Manage certificates, external secrets, and secret stores across your cluster.')}
           </p>
         </div>

--- a/src/components/CertificatesTable.tsx
+++ b/src/components/CertificatesTable.tsx
@@ -132,12 +132,13 @@ export const CertificatesTable: React.FC<CertificatesTableProps> = ({ selectedPr
   });
 
   const columns = [
-    { title: t('Name'), width: 16 },
-    { title: t('Namespace'), width: 10 },
-    { title: t('Secret'), width: 16 },
-    { title: t('Issuer'), width: 16 },
-    { title: t('DNS Names'), width: 20 },
-    { title: t('Status'), width: 12 },
+    { title: t('Name'), width: 14 },
+    { title: t('Namespace'), width: 9 },
+    { title: t('Secret'), width: 14 },
+    { title: t('Issuer'), width: 14 },
+    { title: t('DNS Names'), width: 18 },
+    { title: t('Status'), width: 11 },
+    { title: t('Expiry Date'), width: 10 },
     { title: '', width: 10 }, // Actions column
   ];
 
@@ -160,6 +161,13 @@ export const CertificatesTable: React.FC<CertificatesTableProps> = ({ selectedPr
             <Label color={conditionStatus.color as any} icon={conditionStatus.icon}>
               {conditionStatus.status}
             </Label>
+          ),
+          (
+            <span>
+              {cert.metadata.annotations?.['expiry-date'] ??
+                cert.metadata.annotations?.['expiryDate'] ??
+                '-'}
+            </span>
           ),
           (
             <Dropdown

--- a/src/components/ExternalSecretsTable.tsx
+++ b/src/components/ExternalSecretsTable.tsx
@@ -176,14 +176,15 @@ export const ExternalSecretsTable: React.FC<ExternalSecretsTableProps> = ({ sele
   const loadError = externalSecretsError || clusterExternalSecretsError;
 
   const columns = [
-    { title: t('Name'), width: 15 },
-    { title: t('Type'), width: 9 },
-    { title: t('Namespace'), width: 10 },
-    { title: t('Target Secret'), width: 14 },
-    { title: t('Secret Store'), width: 20 },
-    { title: t('Refresh Interval'), width: 12 },
-    { title: t('Status'), width: 10 },
-    { title: '', width: 10 }, // Actions column
+    { title: t('Name'), width: 14 },
+    { title: t('Type'), width: 8 },
+    { title: t('Namespace'), width: 9 },
+    { title: t('Target Secret'), width: 13 },
+    { title: t('Secret Store'), width: 18 },
+    { title: t('Refresh Interval'), width: 11 },
+    { title: t('Status'), width: 9 },
+    { title: t('Expiry Date'), width: 10 },
+    { title: '', width: 8 }, // Actions column
   ];
 
   const rows = React.useMemo(() => {
@@ -229,6 +230,13 @@ export const ExternalSecretsTable: React.FC<ExternalSecretsTableProps> = ({ sele
             <Label color={conditionStatus.color as any} icon={conditionStatus.icon}>
               {conditionStatus.status}
             </Label>
+          ),
+          (
+            <span>
+              {resource.metadata.annotations?.['expiry-date'] ??
+                resource.metadata.annotations?.['expiryDate'] ??
+                '-'}
+            </span>
           ),
           (
             <Dropdown

--- a/src/components/IssuersTable.tsx
+++ b/src/components/IssuersTable.tsx
@@ -161,14 +161,15 @@ export const IssuersTable: React.FC<IssuersTableProps> = ({ selectedProject }) =
   const loadError = issuersError || clusterIssuersError;
 
   const columns = [
-    { title: t('Name'), width: 14 },
-    { title: t('Namespace'), width: 12 },
-    { title: t('Type'), width: 10 },
-    { title: t('Scope'), width: 10 },
-    { title: t('Issuer Type'), width: 12 },
-    { title: t('Details'), width: 22 },
-    { title: t('Status'), width: 10 },
-    { title: '', width: 10 }, // Actions column
+    { title: t('Name'), width: 13 },
+    { title: t('Namespace'), width: 11 },
+    { title: t('Type'), width: 9 },
+    { title: t('Scope'), width: 9 },
+    { title: t('Issuer Type'), width: 11 },
+    { title: t('Details'), width: 20 },
+    { title: t('Status'), width: 9 },
+    { title: t('Expiry Date'), width: 10 },
+    { title: '', width: 8 }, // Actions column
   ];
 
   const rows = React.useMemo(() => {
@@ -205,6 +206,13 @@ export const IssuersTable: React.FC<IssuersTableProps> = ({ selectedProject }) =
             <Label color={conditionStatus.color as any} icon={conditionStatus.icon}>
               {conditionStatus.status}
             </Label>
+          ),
+          (
+            <span>
+              {issuer.metadata.annotations?.['expiry-date'] ??
+                issuer.metadata.annotations?.['expiryDate'] ??
+                '-'}
+            </span>
           ),
           (
             <Dropdown

--- a/src/components/PushSecretsTable.tsx
+++ b/src/components/PushSecretsTable.tsx
@@ -136,13 +136,14 @@ export const PushSecretsTable: React.FC<PushSecretsTableProps> = ({ selectedProj
   const loadError = pushSecretsError || clusterPushSecretsError;
 
   const columns = [
-    { title: t('Name'), width: 16 },
-    { title: t('Type'), width: 10 },
-    { title: t('Namespace'), width: 12 },
-    { title: t('Secret Store'), width: 18 },
-    { title: t('Source Secret'), width: 16 },
-    { title: t('Refresh Interval'), width: 12 },
-    { title: t('Status'), width: 10 },
+    { title: t('Name'), width: 14 },
+    { title: t('Type'), width: 9 },
+    { title: t('Namespace'), width: 11 },
+    { title: t('Secret Store'), width: 16 },
+    { title: t('Source Secret'), width: 14 },
+    { title: t('Refresh Interval'), width: 11 },
+    { title: t('Status'), width: 9 },
+    { title: t('Expiry Date'), width: 10 },
     { title: '', width: 6 }, // Actions column
   ];
 
@@ -186,6 +187,13 @@ export const PushSecretsTable: React.FC<PushSecretsTableProps> = ({ selectedProj
             <Label color={conditionStatus.color as any} icon={conditionStatus.icon}>
               {conditionStatus.status}
             </Label>
+          ),
+          (
+            <span>
+              {pushSecret.metadata.annotations?.['expiry-date'] ??
+                pushSecret.metadata.annotations?.['expiryDate'] ??
+                '-'}
+            </span>
           ),
           (
             <Dropdown

--- a/src/components/ResourceTable.tsx
+++ b/src/components/ResourceTable.tsx
@@ -84,7 +84,7 @@ export const ResourceTable: React.FC<ResourceTableProps> = ({
   const hasSpecifiedWidths = totalSpecifiedWidth > 0;
   const defaultWidth = hasSpecifiedWidths ? undefined : 100 / columns.length;
 
-  const subtleBorder = '1px solid #3e8635';
+  const subtleBorder = '1px solid #e1e5e9';
 
   return (
     <div className="co-m-table-grid" data-test={dataTest} style={{ border: 'none' }}>

--- a/src/components/ResourceTable.tsx
+++ b/src/components/ResourceTable.tsx
@@ -84,27 +84,39 @@ export const ResourceTable: React.FC<ResourceTableProps> = ({
   const hasSpecifiedWidths = totalSpecifiedWidth > 0;
   const defaultWidth = hasSpecifiedWidths ? undefined : 100 / columns.length;
 
+  const subtleBorder = '1px solid #3e8635';
+
   return (
-    <div className="co-m-table-grid co-m-table-grid--bordered" data-test={dataTest}>
+    <div className="co-m-table-grid" data-test={dataTest} style={{ border: 'none' }}>
       <div className="table-responsive">
-        <table className="table table-hover" style={{ tableLayout: 'fixed', width: '100%' }}>
+        <table
+          className="table table-hover"
+          style={{
+            tableLayout: 'fixed',
+            width: '100%',
+            minWidth: `${columns.length * 110}px`,
+            borderCollapse: 'collapse',
+            border: 'none',
+          }}
+        >
           <thead>
-            <tr>
+            <tr style={{ borderBottom: subtleBorder }}>
               {columns.map((column, index) => {
-                const width = hasSpecifiedWidths 
+                const width = hasSpecifiedWidths
                   ? `${(column.width || 0)}%`
                   : `${defaultWidth}%`;
-                
+
                 return (
-                  <th 
-                    key={index} 
+                  <th
+                    key={index}
                     role="columnheader"
-                    style={{ 
+                    style={{
                       width,
                       paddingLeft: '1rem',
                       paddingRight: '1rem',
                       textAlign: 'left',
-                      verticalAlign: 'middle'
+                      verticalAlign: 'middle',
+                      border: 'none',
                     }}
                   >
                     {column.title}
@@ -115,20 +127,21 @@ export const ResourceTable: React.FC<ResourceTableProps> = ({
           </thead>
           <tbody>
             {rows.map((row, rowIndex) => (
-              <tr key={rowIndex}>
-                {row.cells.map((cell, cellIndex) => (
-                  <td 
-                    key={cellIndex}
+              <tr key={rowIndex} style={{ borderBottom: subtleBorder }}>
+                {columns.map((_column, colIndex) => (
+                  <td
+                    key={colIndex}
                     style={{
                       paddingLeft: '1rem',
                       paddingRight: '1rem',
                       textAlign: 'left',
                       verticalAlign: 'middle',
                       wordWrap: 'break-word',
-                      overflow: 'hidden'
+                      overflow: 'hidden',
+                      border: 'none',
                     }}
                   >
-                    {cell}
+                    {row.cells[colIndex] ?? null}
                   </td>
                 ))}
               </tr>

--- a/src/components/SecretProviderClassTable.tsx
+++ b/src/components/SecretProviderClassTable.tsx
@@ -42,9 +42,9 @@ const getProviderIcon = (provider: string) => {
 };
 
 const getSecretProviderClassStatus = (spc: SecretProviderClass, podStatuses: SecretProviderClassPodStatus[]) => {
-  // Find pod statuses for this SecretProviderClass
+  // Find pod statuses for this SecretProviderClass (skip entries without status)
   const relevantPodStatuses = podStatuses.filter(
-    podStatus => podStatus.status.secretProviderClassName === spc.metadata.name
+    podStatus => podStatus.status?.secretProviderClassName === spc.metadata.name
   );
 
   if (relevantPodStatuses.length === 0) {
@@ -52,7 +52,7 @@ const getSecretProviderClassStatus = (spc: SecretProviderClass, podStatuses: Sec
   }
 
   // Check if any pod has this SecretProviderClass mounted
-  const mountedPods = relevantPodStatuses.filter(podStatus => podStatus.status.mounted === true);
+  const mountedPods = relevantPodStatuses.filter(podStatus => podStatus.status?.mounted === true);
 
   if (mountedPods.length > 0) {
     return { status: 'Ready', icon: <CheckCircleIcon />, color: 'green' };
@@ -143,13 +143,14 @@ export const SecretProviderClassTable: React.FC<SecretProviderClassTableProps> =
   const loadError = spcLoadError || podStatusesLoadError;
 
   const columns = [
-    { title: t('Name'), width: 16 },
-    { title: t('Namespace'), width: 12 },
-    { title: t('Provider'), width: 12 },
-    { title: t('Secret Objects'), width: 14 },
-    { title: t('Parameters'), width: 24 },
-    { title: t('Status'), width: 12 },
-    { title: '', width: 10 }, // Actions column
+    { title: t('Name'), width: 14 },
+    { title: t('Namespace'), width: 11 },
+    { title: t('Provider'), width: 11 },
+    { title: t('Secret Objects'), width: 12 },
+    { title: t('Parameters'), width: 21 },
+    { title: t('Status'), width: 11 },
+    { title: t('Expiry Date'), width: 11 },
+    { title: '', width: 9 }, // Actions column
   ];
 
   const rows = React.useMemo(() => {
@@ -187,6 +188,13 @@ export const SecretProviderClassTable: React.FC<SecretProviderClassTableProps> =
             <Label color={conditionStatus.color as any} icon={conditionStatus.icon}>
               {conditionStatus.status}
             </Label>
+          ),
+          (
+            <span>
+              {spc.metadata.annotations?.['expiry-date'] ??
+                spc.metadata.annotations?.['expiryDate'] ??
+                '-'}
+            </span>
           ),
           (
             <Dropdown

--- a/src/components/SecretStoresTable.tsx
+++ b/src/components/SecretStoresTable.tsx
@@ -188,14 +188,15 @@ export const SecretStoresTable: React.FC<SecretStoresTableProps> = ({ selectedPr
   const loadError = secretStoresError || clusterSecretStoresError;
 
   const columns = [
-    { title: t('Name'), width: 14 },
-    { title: t('Namespace'), width: 12 },
-    { title: t('Type'), width: 10 },
-    { title: t('Scope'), width: 8 },
-    { title: t('Provider'), width: 14 },
-    { title: t('Details'), width: 22 },
-    { title: t('Status'), width: 10 },
-    { title: '', width: 10 }, // Actions column
+    { title: t('Name'), width: 13 },
+    { title: t('Namespace'), width: 11 },
+    { title: t('Type'), width: 9 },
+    { title: t('Scope'), width: 7 },
+    { title: t('Provider'), width: 13 },
+    { title: t('Details'), width: 20 },
+    { title: t('Status'), width: 9 },
+    { title: t('Expiry Date'), width: 10 },
+    { title: '', width: 8 }, // Actions column
   ];
 
   const rows = React.useMemo(() => {
@@ -224,6 +225,13 @@ export const SecretStoresTable: React.FC<SecretStoresTableProps> = ({ selectedPr
             <Label color={conditionStatus.color as any} icon={conditionStatus.icon}>
               {conditionStatus.status}
             </Label>
+          ),
+          (
+            <span>
+              {secretStore.metadata.annotations?.['expiry-date'] ??
+                secretStore.metadata.annotations?.['expiryDate'] ??
+                '-'}
+            </span>
           ),
           (
             <Dropdown

--- a/src/components/crds/Certificate.ts
+++ b/src/components/crds/Certificate.ts
@@ -10,6 +10,7 @@ export interface Certificate {
     name: string;
     namespace: string;
     creationTimestamp: string;
+    annotations?: Record<string, string>;
   };
   spec: {
     secretName: string;

--- a/src/components/crds/ExternalSecret.ts
+++ b/src/components/crds/ExternalSecret.ts
@@ -17,6 +17,7 @@ export interface ExternalSecret {
     name: string;
     namespace: string;
     creationTimestamp: string;
+    annotations?: Record<string, string>;
   };
   spec: {
     secretStoreRef?: {
@@ -53,6 +54,7 @@ export interface ClusterExternalSecret {
     name: string;
     namespace?: string; // ClusterExternalSecret is cluster-scoped
     creationTimestamp: string;
+    annotations?: Record<string, string>;
   };
   spec: {
     externalSecretSpec: {

--- a/src/components/crds/Issuer.ts
+++ b/src/components/crds/Issuer.ts
@@ -16,6 +16,7 @@ export interface Issuer {
     name: string;
     namespace?: string;
     creationTimestamp: string;
+    annotations?: Record<string, string>;
   };
   spec: {
     acme?: {

--- a/src/components/crds/SecretProviderClass.ts
+++ b/src/components/crds/SecretProviderClass.ts
@@ -51,7 +51,7 @@ export interface SecretProviderClassPodStatus {
     namespace: string;
     creationTimestamp?: string;
   };
-  status: {
+  status?: {
     mounted: boolean;
     secretProviderClassName: string;
     podName?: string;

--- a/src/components/crds/SecretStore.ts
+++ b/src/components/crds/SecretStore.ts
@@ -16,6 +16,7 @@ export interface SecretStore {
     name: string;
     namespace?: string;
     creationTimestamp: string;
+    annotations?: Record<string, string>;
   };
   scope?: 'Namespace' | 'Cluster';
   spec: {


### PR DESCRIPTION
Added an Expiry Date column to all six resource tables (Certificates, Issuers, External Secrets, Secret Stores, Push Secrets, Secret Provider Classes), using annotations or - when missing.
Fixed SecretProviderClassPodStatus handling so missing status no longer causes runtime errors (optional type + optional chaining).
ResourceTable: body cells aligned to columns by index, table given a min width for horizontal scroll, borders changed from green to light grey.
CRD types: added optional metadata.annotations where needed for expiry display and TypeScript

<img width="1611" height="931" alt="Screenshot 2026-02-12 at 09-03-26 Secrets Management" src="https://github.com/user-attachments/assets/bccf5e54-a484-4039-bac8-58cfe0068589" />